### PR TITLE
Fix typo in broker api docs use cases page

### DIFF
--- a/content/use-cases/_index.md
+++ b/content/use-cases/_index.md
@@ -19,7 +19,7 @@ of use cases.
 We support most use cases internationally.
 
 Depending on the case, the API methods you want to use could vary. For
-example, the omnibus borker-dealer case never uses API to open a customer
+example, the omnibus broker-dealer case never uses API to open a customer
 account since the trading accounts are created upfront and you will submit
 orders to them, and manage your end customer accounting on your end. More
 details on each use case are described in the following section.


### PR DESCRIPTION
Hi,

Nice job on the launch of Alpaca Broker API. I was reading the docs and noticed this typo.

Thanks, Jon