### PR TITLE
Update funding doc for "Post-trade Settlement"

### DIFF
--- a/content/integration/funding.md
+++ b/content/integration/funding.md
@@ -59,7 +59,10 @@ the local requirements.
 
 As international money transfers can take days usually, under certain
 conditions, Alpaca supports instant deposit for better user experience. Please
-contact us for more details. Post-trade Settlement We support the post-trade
-settlement process. Please contact us for more details.
+contact us for more details. 
+
+## Post-trade Settlement 
+
+We support the post-trade settlement process. Please contact us for more details.
 
 &nbsp;


### PR DESCRIPTION
The original doc around "Post-trade Settlement" part looks unusual. 

should "Post-trade Settlement" belong to "Instance Deposit" section or it should be its own section ?