### PR TITLE
Fix ExchangeType and JournalStatus mismatches

### DIFF
--- a/content/api-references/assets.md
+++ b/content/api-references/assets.md
@@ -38,7 +38,7 @@ Assets are sorted by asset class, exchange and symbol. Some assets are not trada
 | ---------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `id`             | string.UUID | Asset ID                                                                                                                                                    |
 | `class`          | string      | Always `us_equity`                                                                                                                                          |
-| `exchange`       | string      | `AMEX`, `ARCA`, `BATS`, `NYSE`, `NASDAQ`, `NYSEARCA`                                                                                                        |
+| `exchange`       | string      | `AMEX`, `ARCA`, `BATS`, `NYSE`, `NASDAQ`, `NYSEARCA`, `OTC`                                                                                                 |
 | `symbol`         | string      | The symbol of the asset                                                                                                                                     |
 | `name`           | string      | The official name of the asset                                                                                                                              |
 | `status`         | string      | `ACTIVE` or `INACTIVE`                                                                                                                                      |

--- a/content/api-references/journals.md
+++ b/content/api-references/journals.md
@@ -80,14 +80,14 @@ For more on Journals click [here]({{< relref "../../integration/funding/#cash-po
 
 | Status             | Description                                                                                                                                                   |
 | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `QUEUED`           | Journal in queue to be processed. Journal is not processed yet.                                                                                               |
-| `SENT_TO_CLEARING` | Journal sent to be processed. Journal is not processed yet.                                                                                                   |
-| `PENDING`          | Journal pending to be processed.                                                                                                                              |
-| `EXECUTED`         | Journal executed and balances updated for both sides of the journal transaction. This is _not_ a final status, journals can be reversed if there is an error. |
-| `REJECTED`         | Journal rejected. Please try again.                                                                                                                           |
-| `CANCELED`         | Journal canceled. This is a **FINAL** status.                                                                                                                 |
-| `REFUSED`          | Journal refused. Please try again.                                                                                                                            |
-| `DELETED`          | Journal deleted. This is a **FINAL** status.                                                                                                                  |
+| `queued`           | Journal in queue to be processed. Journal is not processed yet.                                                                                               |
+| `sent_to_clearing` | Journal sent to be processed. Journal is not processed yet.                                                                                                   |
+| `pending`          | Journal pending to be processed.                                                                                                                              |
+| `executed`         | Journal executed and balances updated for both sides of the journal transaction. This is _not_ a final status, journals can be reversed if there is an error. |
+| `rejected`         | Journal rejected. Please try again.                                                                                                                           |
+| `canceled`         | Journal canceled. This is a **FINAL** status.                                                                                                                 |
+| `refued`          | Journal refused. Please try again.                                                                                                                            |
+| `deleted`          | Journal deleted. This is a **FINAL** status.                                                                                                                  |
 
 ---
 


### PR DESCRIPTION
(1) In the example journal JSON blob and in the API, the statuses are in lower case. However, in the list describing what they individually mean, they are UPPERCASE. Fix this mismatch to be consistent with the API behavior.

(2) When pulling down all the assets, I got an asset with undocumented exchange type OTC. Can the Alpaca team confirm that the list of exchange types is exhaustive? Thanks!