### PR TITLE
Add completed transfer type

### DIFF
--- a/content/api-references/funding/transfers.md
+++ b/content/api-references/funding/transfers.md
@@ -56,12 +56,13 @@ Transfers allow you to transfer money/balance into your end customers' account (
 
 ### ENUM.TransferStatus
 
-| Attribute  | Description                                  |
-| ---------- | -------------------------------------------- |
-| `QUEUED`   | Transfer is in queue to be processed         |
-| `PENDING`  | Transfer is pending processing               |
-| `REJECTED` | Transfer is rejected                         |
-| `APPROVED` | Transfer is approved. This is a final state. |
+| Attribute   | Description                                   |
+| ----------- | --------------------------------------------- |
+| `QUEUED`    | Transfer is in queue to be processed          |
+| `PENDING`   | Transfer is pending processing                |
+| `REJECTED`  | Transfer is rejected                          |
+| `APPROVED`  | Transfer is approved. This is a final state.  |
+| `COMPLETED` | Transfer is completed. This is a final state. |
 
 ### ENUM.TransferDirection
 


### PR DESCRIPTION
I wrote the description of COMPLETED based on my knowledge of the word :) but if there is anything else to know about this state, would be awesome to get feedback from Alpaca.

I am getting this enum type in the sandbox and the type COMPLETED is referenced above in the example response.