### PR TITLE
Add MarketDay schema for /calendar api route

### DIFF
--- a/assets/openapi.yaml
+++ b/assets/openapi.yaml
@@ -1615,6 +1615,29 @@ components:
           type: string
         change_today:
           type: string
+    MarketDay:
+      title: MarketDay
+      type: object
+      properties:
+        date:
+          type: string
+          example: "2021-04-06"
+        open:
+          type: string
+          example: "09:30"
+        close:
+          type: string
+          example: "16:00"
+        session_open:
+          type: string
+          example: "0700"
+        session_close:
+          type: string
+          example: "1900"
+      required:
+        - date
+        - open
+        - close
   responses:
     Forbidden:
       description: Request is forbidden
@@ -2163,17 +2186,9 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  date:
-                    type: string
-                    example: '2021-04-06'
-                  open:
-                    type: string
-                    example: '09:30'
-                  close:
-                    type: string
-                    example: '16:00'
+                type: array
+                items:
+                  $ref: "#/components/schemas/MarketDay"
   /clock:
     get:
       security:


### PR DESCRIPTION
This fixes the incorrect typing of the /calendar API route, which returns an array but is typed as an object. *This is also incorrect on the [docs webpage](https://alpaca.markets/docs/broker/api-references/calendar/)*