### PR TITLE
Make provider_name a list of strings

### DIFF
--- a/content/api-references/accounts/accounts.md
+++ b/content/api-references/accounts/accounts.md
@@ -592,7 +592,7 @@ Procedures for identity verification include documents (for example, driver’s 
 
 ```json
 {
-  "provider_name": "onfido",
+  "provider_name": ["onfido"],
   "kyc": {
     "id": "CBDAD1C4-1047-450E-BAE5-B6C406F509B4",
     "risk_level": "LOW",


### PR DESCRIPTION
API reference to change : https://alpaca.markets/docs/broker/api-references/accounts/accounts/#uploading-cip-information. 
provider_name now accepts a list of cip providers