### PR TITLE
fix(openapi): parameters in int32 format must have integer type

### DIFF
--- a/assets/openapi.yaml
+++ b/assets/openapi.yaml
@@ -2212,12 +2212,12 @@ paths:
         - name: limit
           in: query
           schema:
-            type: number
+            type: integer
             format: int32
         - name: offset
           in: query
           schema:
-            type: number
+            type: integer
             format: int32
       responses:
         '200':


### PR DESCRIPTION
## WHAT
- change type of `limit` and `offset` param of `/accounts/{account_id}/transfers` endpoint from number to integer

## WHY
https://swagger.io/docs/specification/data-models/data-types/#numbers
parameters in `int32` format must have `integer` type, not `number` type.

I found this when I tried to generate a client code by https://github.com/deepmap/oapi-codegen and the following error is shown:
```
$ oapi-codegen openapi.yaml > openapi-client.gen.go

error generating code: error creating operation definitions: error describing global parameters for GET//accounts/{account_id}/transfers: error generating type for param (limit): error resolving primitive type
```

