### PR TITLE
openapi.yaml: TradeUpdatesEvent/execution_id

### DIFF
--- a/assets/openapi.yaml
+++ b/assets/openapi.yaml
@@ -1874,7 +1874,8 @@ components:
         event_id:
           type: integer
         execution_id:
-          type: integer
+          type: string
+          format: uuid
         order:
           $ref: '#/components/schemas/Order'
       required:


### PR DESCRIPTION
According to the [docs](https://alpaca.markets/docs/api-references/broker-api/events/#response-2), TradeUpdatesEvent/execution_id should be a UUID string, not an integer (in real life this is true as well).

Copy of https://github.com/alpacahq/bkdocs/pull/116 but with UUID part.